### PR TITLE
Implement basic ETL skeleton

### DIFF
--- a/infra/src/etl-stack.js
+++ b/infra/src/etl-stack.js
@@ -1,0 +1,29 @@
+const cdk = require('aws-cdk-lib');
+const lambda = require('aws-cdk-lib/aws-lambda');
+const events = require('aws-cdk-lib/aws-events');
+const targets = require('aws-cdk-lib/aws-events-targets');
+
+class EtlStack extends cdk.Stack {
+  constructor(scope, id, props) {
+    super(scope, id, props);
+
+    const func = new lambda.Function(this, 'EtlHandler', {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      code: lambda.Code.fromAsset('../services/etl/dist'),
+      handler: 'index.handler',
+      environment: {},
+    });
+
+    new events.Rule(this, 'ShallowRule', {
+      schedule: events.Schedule.cron({ minute: '*/5', hour: '*' }),
+      targets: [new targets.LambdaFunction(func)],
+    });
+
+    new events.Rule(this, 'DeepRule', {
+      schedule: events.Schedule.cron({ minute: '0', hour: '*/1' }),
+      targets: [new targets.LambdaFunction(func)],
+    });
+  }
+}
+
+module.exports = { EtlStack };

--- a/infra/src/index.js
+++ b/infra/src/index.js
@@ -1,1 +1,5 @@
-console.log('infra');
+const cdk = require('aws-cdk-lib');
+const { EtlStack } = require('./etl-stack');
+
+const app = new cdk.App();
+new EtlStack(app, 'EtlStack');

--- a/services/etl/docker-compose.yml
+++ b/services/etl/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.9'
+services:
+  db:
+    image: timescale/timescaledb-postgis:latest-pg14
+    environment:
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - '5432:5432'
+    volumes:
+      - db_data:/var/lib/postgresql/data
+volumes:
+  db_data:

--- a/services/etl/package.json
+++ b/services/etl/package.json
@@ -4,5 +4,9 @@
   "private": true,
   "scripts": {
     "build": "echo building etl && mkdir -p dist && cp src/index.js dist/index.js"
+  },
+  "dependencies": {
+    "node-fetch": "^3.3.2",
+    "pg": "^8.11.3"
   }
 }

--- a/services/etl/src/index.js
+++ b/services/etl/src/index.js
@@ -1,1 +1,21 @@
-console.log('etl');
+const { fetchMarketSlice } = require('./lib/coinmarketcap');
+const { fetchAssetDeep } = require('./lib/coingecko');
+const { reconcile } = require('./lib/reconcile');
+const { upsertSnapshot } = require('./lib/db');
+
+async function run() {
+  const apiKey = process.env.CMC_API_KEY || '';
+  const slice = await fetchMarketSlice(apiKey);
+
+  for (const asset of slice) {
+    const cg = await fetchAssetDeep(asset.id);
+    const discrepancies = reconcile(cg, asset);
+    const record = { ...asset, ...cg, discrepancies };
+    await upsertSnapshot(asset.id, new Date().toISOString(), record);
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/services/etl/src/lib/coingecko.js
+++ b/services/etl/src/lib/coingecko.js
@@ -1,0 +1,22 @@
+const fetch = require('node-fetch');
+
+async function fetchAssetDeep(id) {
+  const url = `https://api.coingecko.com/api/v3/coins/${id}?localization=false&developer_data=true`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`CoinGecko request failed: ${res.status}`);
+  }
+  const data = await res.json();
+  const dev = data.developer_data || {};
+  const community = data.community_data || {};
+  return {
+    id: data.id,
+    symbol: data.symbol,
+    name: data.name,
+    commits_4_weeks: dev.commit_count_4_weeks,
+    pull_request_contributors: dev.pull_request_contributors,
+    active_addresses: community.active_addresses,
+  };
+}
+
+module.exports = { fetchAssetDeep };

--- a/services/etl/src/lib/coinmarketcap.js
+++ b/services/etl/src/lib/coinmarketcap.js
@@ -1,0 +1,27 @@
+const fetch = require('node-fetch');
+
+const API_URL = 'https://pro-api.coinmarketcap.com/v1/cryptocurrency/listings/latest';
+
+async function fetchMarketSlice(apiKey) {
+  const res = await fetch(`${API_URL}?limit=500`, {
+    headers: {
+      'X-CMC_PRO_API_KEY': apiKey,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`CMC request failed: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.data
+    .filter((asset) => asset.cmc_rank > 20 && asset.quote && asset.quote.USD && asset.quote.USD.market_cap >= 1e9)
+    .map((asset) => ({
+      id: asset.id,
+      symbol: asset.symbol,
+      name: asset.name,
+      price: asset.quote.USD.price,
+      market_cap: asset.quote.USD.market_cap,
+      volume_24h: asset.quote.USD.volume_24h,
+    }));
+}
+
+module.exports = { fetchMarketSlice };

--- a/services/etl/src/lib/db.js
+++ b/services/etl/src/lib/db.js
@@ -1,0 +1,16 @@
+const { Pool } = require('pg');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/metrics',
+});
+
+async function upsertSnapshot(assetId, ts, data) {
+  await pool.query(
+    `INSERT INTO asset_snapshots (asset_id, ts, data)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (asset_id, ts) DO UPDATE SET data = EXCLUDED.data`,
+    [assetId, ts, data]
+  );
+}
+
+module.exports = { pool, upsertSnapshot };

--- a/services/etl/src/lib/reconcile.js
+++ b/services/etl/src/lib/reconcile.js
@@ -1,0 +1,24 @@
+function reconcile(cgData, cmcData) {
+  const discrepancies = [];
+  const fields = [
+    ['price', 'price'],
+    ['market_cap', 'market_cap'],
+    ['volume_24h', 'volume_24h'],
+  ];
+
+  fields.forEach(([cgField, cmcField]) => {
+    const cgVal = cgData[cgField];
+    const cmcVal = cmcData[cmcField];
+    if (typeof cgVal === 'number' && typeof cmcVal === 'number') {
+      const avg = (cgVal + cmcVal) / 2;
+      const diff = Math.abs(cgVal - cmcVal);
+      if (avg > 0 && diff / avg > 0.05) {
+        discrepancies.push({ field: cgField, cg: cgVal, cmc: cmcVal });
+      }
+    }
+  });
+
+  return discrepancies;
+}
+
+module.exports = { reconcile };

--- a/services/etl/test/integration/db.test.js
+++ b/services/etl/test/integration/db.test.js
@@ -1,0 +1,20 @@
+const { pool, upsertSnapshot } = require('../../src/lib/db');
+
+async function run() {
+  await pool.query(`CREATE TABLE IF NOT EXISTS asset_snapshots (
+    asset_id text,
+    ts timestamptz,
+    data jsonb,
+    PRIMARY KEY(asset_id, ts)
+  );`);
+
+  await upsertSnapshot('btc', new Date().toISOString(), { ok: true });
+  const { rows } = await pool.query('SELECT * FROM asset_snapshots');
+  console.log(rows);
+  await pool.end();
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/services/etl/test/reconcile.test.js
+++ b/services/etl/test/reconcile.test.js
@@ -1,0 +1,7 @@
+const { reconcile } = require('../src/lib/reconcile');
+
+const cg = { price: 10, market_cap: 200, volume_24h: 50 };
+const cmc = { price: 10.7, market_cap: 180, volume_24h: 49 };
+
+const result = reconcile(cg, cmc);
+console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
## Summary
- add CoinMarketCap and CoinGecko fetchers
- implement reconcile engine
- add TimescaleDB connector and docker compose file
- create basic CDK stack for scheduled ETL
- include sample tests

## Testing
- `node services/etl/test/reconcile.test.js`
- `node services/etl/test/integration/db.test.js` *(fails: Cannot find module 'pg')*